### PR TITLE
feat: Adding new exclusion attribute to allow for prefix matching of logical resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,4 +70,9 @@ provider:
       # This property allows you to intentionally remove a resource.
       ExcludeResource:
         - LogicalResourceId/LoggingBucket
+
+      # Any resources matching this prefix are excluded from `Resource` after all resources by type are added.
+      # This property allows you to intentionally remove a collection of resources which share the same prefix.
+      ExcludeResourcePrefix:
+        - LogicalResourceId/Logging
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-stack-policy-by-resource-type",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-stack-policy-by-resource-type",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Serverless Framework plugin for automatically populating CloudFormation stack policy statements by resource type.",
   "main": "src/index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -153,6 +153,7 @@ describe('index', function() {
       ]);
       should.not.exist(statement.ResourceType);
       should.not.exist(statement.ExcludeResource);
+      should.not.exist(statement.ExcludeResourcePrefix);
     });
 
     it("filters out resources based on 'ExcludeResource' in the stack policy statement", function() {
@@ -191,6 +192,7 @@ describe('index', function() {
       ]);
       should.not.exist(statement.ResourceType);
       should.not.exist(statement.ExcludeResource);
+      should.not.exist(statement.ExcludeResourcePrefix);
     });
 
     it("filters out resources based on 'ExcludeResourcePrefix' in the stack policy statement", function() {
@@ -229,6 +231,7 @@ describe('index', function() {
       ]);
       should.not.exist(statement.ResourceType);
       should.not.exist(statement.ExcludeResource);
+      should.not.exist(statement.ExcludeResourcePrefix);
     });
 
     it("filters out resources based on 'ExcludeResource' and  'ExcludeResourcePrefix' in the stack policy statement", function() {
@@ -269,6 +272,7 @@ describe('index', function() {
       ]);
       should.not.exist(statement.ResourceType);
       should.not.exist(statement.ExcludeResource);
+      should.not.exist(statement.ExcludeResourcePrefix);
     });
 
     it("works even if 'Resource' property does not exist in the stack policy statement", function() {

--- a/test/index.js
+++ b/test/index.js
@@ -79,7 +79,7 @@ describe('index', function() {
         this.serverless.service.resources.Resources,
         { DDBTable: createDdbResource() },
         { S3Bucket1: createS3Resource() },
-        { S3Bucket2: createS3Resource() }
+        { AnotherS3Bucket: createS3Resource() }
       );
     });
 
@@ -149,7 +149,7 @@ describe('index', function() {
       statement.Resource.should.have.members([
         'LogicalResourceId/DDBTable',
         'LogicalResourceId/S3Bucket1',
-        'LogicalResourceId/S3Bucket2'
+        'LogicalResourceId/AnotherS3Bucket'
       ]);
       should.not.exist(statement.ResourceType);
       should.not.exist(statement.ExcludeResource);
@@ -187,7 +187,85 @@ describe('index', function() {
       this.plugin.lookupLogicalResourceIds();
       statement.Resource.should.have.members([
         'LogicalResourceId/DDBTable',
-        'LogicalResourceId/S3Bucket2'
+        'LogicalResourceId/AnotherS3Bucket'
+      ]);
+      should.not.exist(statement.ResourceType);
+      should.not.exist(statement.ExcludeResource);
+    });
+
+    it("filters out resources based on 'ExcludeResourcePrefix' in the stack policy statement", function() {
+      const statement = {
+        Effect: 'Deny',
+        Principal: '*',
+        Action: [
+          'Update:Replace',
+          'Update:Delete'
+        ],
+        Resource: [
+          'LogicalResourceId/DDBTable'
+        ],
+        ResourceType: [
+          'AWS::S3::Bucket'
+        ],
+        ExcludeResourcePrefix: [
+          'LogicalResourceId/S3Buck'
+        ]
+      };
+
+      this.serverless.service.provider.stackPolicy.push(
+        {
+          Effect: 'Allow',
+          Principal: '*',
+          Action: 'Update:*',
+          Resource: '*'
+        },
+        statement
+      );
+
+      this.plugin.lookupLogicalResourceIds();
+      statement.Resource.should.have.members([
+        'LogicalResourceId/DDBTable',
+        'LogicalResourceId/AnotherS3Bucket'
+      ]);
+      should.not.exist(statement.ResourceType);
+      should.not.exist(statement.ExcludeResource);
+    });
+
+    it("filters out resources based on 'ExcludeResource' and  'ExcludeResourcePrefix' in the stack policy statement", function() {
+      const statement = {
+        Effect: 'Deny',
+        Principal: '*',
+        Action: [
+          'Update:Replace',
+          'Update:Delete'
+        ],
+        Resource: [
+          'LogicalResourceId/DDBTable'
+        ],
+        ResourceType: [
+          'AWS::S3::Bucket'
+        ],
+        ExcludeResource: [
+          'LogicalResourceId/S3Bucket1'
+        ],
+        ExcludeResourcePrefix: [
+          'LogicalResourceId/Another'
+        ]
+      };
+
+      this.serverless.service.provider.stackPolicy.push(
+        {
+          Effect: 'Allow',
+          Principal: '*',
+          Action: 'Update:*',
+          Resource: '*'
+        },
+        statement
+      );
+
+      this.plugin.lookupLogicalResourceIds();
+      statement.Resource.should.have.members([
+        'LogicalResourceId/DDBTable'
       ]);
       should.not.exist(statement.ResourceType);
       should.not.exist(statement.ExcludeResource);
@@ -221,10 +299,10 @@ describe('index', function() {
 
       this.plugin.lookupLogicalResourceIds();
       statement.Resource.should.have.members([
-        'LogicalResourceId/S3Bucket2'
+        'LogicalResourceId/AnotherS3Bucket'
       ]);
       should.not.exist(statement.ResourceType);
-      should.not.exist(statement.ExcludeResource);
+      should.not.exist(statement.ExcludeResourcePrefix);
     });
   });
 });


### PR DESCRIPTION
**PR Summary**
Streamline necessary serverless.yml manipulation by allowing exclusion based off of string prefix.
Does not impede any of the existing attributes.